### PR TITLE
refactor: use time.RFC3339Nano format

### DIFF
--- a/internal/database/ids.go
+++ b/internal/database/ids.go
@@ -3,7 +3,6 @@ package database
 import (
 	"bytes"
 	"fmt"
-	"github.com/redhatinsights/xjoin-go-lib/pkg/utils"
 	"text/template"
 	"time"
 )
@@ -12,7 +11,7 @@ func (d *DBClient) GetIDsByModifiedOn(start time.Time, end time.Time) (ids []str
 	//TODO: parse name of id and modified_on fields from avro schema
 	query := fmt.Sprintf(
 		`SELECT id FROM %s WHERE modified_on > '%s' AND modified_on < '%s' ORDER BY id `,
-		d.Config.Table, start.Format(utils.TimeFormat()), end.Format(utils.TimeFormat()))
+		d.Config.Table, start.Format(time.RFC3339Nano), end.Format(time.RFC3339Nano))
 
 	return d.queryIds(query)
 }

--- a/internal/elasticsearch/ids.go
+++ b/internal/elasticsearch/ids.go
@@ -15,7 +15,7 @@ import (
 func (e *ESClient) GetIDsByModifiedOn(start time.Time, end time.Time) (ids []string, err error) {
 	modifiedOnField := e.rootNode + ".modified_on" //TODO: parse modified_on field name from avro schema
 	reqJSON := []byte(fmt.Sprintf(`{"query":{"range":{"%s":{"lt":"%s","gt":"%s"}}}}`,
-		modifiedOnField, end.Format(utils.TimeFormat()), start.Format(utils.TimeFormat())))
+		modifiedOnField, end.UTC().Format(time.RFC3339Nano), start.UTC().Format(time.RFC3339Nano)))
 
 	return e.getIDsQuery(e.index, reqJSON)
 }

--- a/internal/validator/id_test.go
+++ b/internal/validator/id_test.go
@@ -2,14 +2,14 @@ package validator_test
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/RedHatInsights/xjoin-validation/internal/test"
 	. "github.com/RedHatInsights/xjoin-validation/internal/validator"
 	"github.com/jarcoal/httpmock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/redhatinsights/xjoin-go-lib/pkg/utils"
-	"time"
 )
 
 var _ = Describe("ID validation", func() {
@@ -33,7 +33,7 @@ var _ = Describe("ID validation", func() {
 
 			dbMock.ExpectQuery(fmt.Sprintf(
 				`SELECT id FROM hosts WHERE modified_on > '%s' AND modified_on < '%s' ORDER BY id`,
-				startTime.Format(utils.TimeFormat()), endTime.Format(utils.TimeFormat()))).
+				startTime.Format(time.RFC3339Nano), endTime.Format(time.RFC3339Nano))).
 				WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("1234"))
 
 			httpmock.RegisterResponder(
@@ -72,7 +72,7 @@ var _ = Describe("ID validation", func() {
 
 			dbMock.ExpectQuery(fmt.Sprintf(
 				`SELECT id FROM hosts WHERE modified_on > '%s' AND modified_on < '%s' ORDER BY id`,
-				startTime.Format(utils.TimeFormat()), endTime.Format(utils.TimeFormat()))).
+				startTime.Format(time.RFC3339Nano), endTime.Format(time.RFC3339Nano))).
 				WillReturnRows(sqlmock.NewRows([]string{"id"}))
 
 			httpmock.RegisterResponder(
@@ -106,7 +106,7 @@ var _ = Describe("ID validation", func() {
 
 			dbMock.ExpectQuery(fmt.Sprintf(
 				`SELECT id FROM hosts WHERE modified_on > '%s' AND modified_on < '%s' ORDER BY id`,
-				startTime.Format(utils.TimeFormat()), endTime.Format(utils.TimeFormat()))).
+				startTime.Format(time.RFC3339Nano), endTime.Format(time.RFC3339Nano))).
 				WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("1234"))
 
 			httpmock.RegisterResponder(
@@ -138,7 +138,7 @@ var _ = Describe("ID validation", func() {
 
 			dbMock.ExpectQuery(fmt.Sprintf(
 				`SELECT id FROM hosts WHERE modified_on > '%s' AND modified_on < '%s' ORDER BY id`,
-				startTime.Format(utils.TimeFormat()), endTime.Format(utils.TimeFormat()))).
+				startTime.Format(time.RFC3339Nano), endTime.Format(time.RFC3339Nano))).
 				WillReturnRows(sqlmock.NewRows([]string{"id"}))
 
 			httpmock.RegisterResponder(
@@ -177,7 +177,7 @@ var _ = Describe("ID validation", func() {
 
 			dbMock.ExpectQuery(fmt.Sprintf(
 				`SELECT id FROM hosts WHERE modified_on > '%s' AND modified_on < '%s' ORDER BY id`,
-				startTime.Format(utils.TimeFormat()), endTime.Format(utils.TimeFormat()))).
+				startTime.Format(time.RFC3339Nano), endTime.Format(time.RFC3339Nano))).
 				WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("5678"))
 
 			httpmock.RegisterResponder(
@@ -216,7 +216,7 @@ var _ = Describe("ID validation", func() {
 
 			dbMock.ExpectQuery(fmt.Sprintf(
 				`SELECT id FROM hosts WHERE modified_on > '%s' AND modified_on < '%s' ORDER BY id`,
-				startTime.Format(utils.TimeFormat()), endTime.Format(utils.TimeFormat()))).
+				startTime.Format(time.RFC3339Nano), endTime.Format(time.RFC3339Nano))).
 				WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("in.both").AddRow("db.only.1").AddRow("db.only.2"))
 
 			httpmock.RegisterResponder(


### PR DESCRIPTION
Standardize timeformat on [`time.RFC3339Nano`](https://pkg.go.dev/time@go1.18#pkg-constants).

Previous format was [`2006-01-02T15:04:05.999999999`](https://github.com/RedHatInsights/xjoin-go-lib/blob/24227803ebad47655e6a3b3eb6ab3987bed0478c/pkg/utils/lang.go#L100).

References: 
* https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-range-query.html
* https://www.postgresql.org/docs/13/datatype-datetime.html

ESSNTL-4192