### PR TITLE
ci: Add GitHub actions for linting Go code

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,41 @@
+name: Lint
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  lint-code:
+    name: Lint code
+    runs-on: ubuntu-latest
+    steps:
+      - name: Updating ...
+        run: sudo apt-get -qq update
+
+      - name: Set up go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.18"
+          cache: false
+
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: "latest"
+          args: "--verbose --timeout 5m"
+
+  lint-language:
+    name: Lint language
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Run woke
+        uses: get-woke/woke-action@v0
+        with:
+          fail-on-error: false

--- a/internal/elasticsearch/ids.go
+++ b/internal/elasticsearch/ids.go
@@ -92,7 +92,7 @@ func (e *ESClient) getIDsQuery(index string, reqJSON []byte) (responseIds []stri
 	moreHits := true
 	scrollID := searchJSON.ScrollID
 
-	for moreHits == true {
+	for moreHits {
 		scrollReq := esapi.ScrollRequest{
 			Scroll:   time.Duration(1) * time.Minute,
 			ScrollID: scrollID,

--- a/internal/validator/content.go
+++ b/internal/validator/content.go
@@ -72,8 +72,6 @@ func (v *Validator) validateFullChunkAsync(chunk []string, allIdDiffs chan idDif
 	for _, diff := range diffs {
 		allIdDiffs <- diff
 	}
-
-	return
 }
 
 func (v *Validator) ValidateContent() (result ValidateContentResult, err error) {


### PR DESCRIPTION
This patch adds actions to lint Go code with `golangci-lint`, and fixes all the issues returned by this tool. It also includes tooling to detect non-inclusive language in the source code. Note that is non voting for now.

```
internal/elasticsearch/ids.go:95:6: S1002: should omit comparison to bool constant, can be simplified to `moreHits` (gosimple)
        for moreHits == true {
            ^
internal/validator/content.go:76:2: S1023: redundant `return` statement (gosimple)
        return
        ^
```